### PR TITLE
Fix: propshaft missing asset error

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project aims to simplify the development of LLM applications using Ruby on 
 $ bundle install
 $ EDITOR=vim bundle exec bin/rails credentials:edit # to supply your openai keys 
 $ bundle exec bin/setup
+$ bin/rails assets:precompile
 $ bundle exec bin/dev
 
 ```


### PR DESCRIPTION
**Description:**
This PR updates the README file under the **INSTALL (Normal Mode)** section to include the `bin/rails assets:precompile` step, which resolves the `Propshaft::MissingAssetError`.

**Changes Made:**
- Updated the **INSTALL (Normal Mode)** section in the README file to include the following:

```markdown
$ bundle install
$ EDITOR=vim bundle exec bin/rails credentials:edit # to supply your openai keys
$ bundle exec bin/setup
$ bin/rails assets:precompile
$ bundle exec bin/dev
```

**Testing:**
1. Follow the updated README instructions to set up the application.
2. Ensure the error does not appear, and the application starts successfully.

Issue: #23 